### PR TITLE
Add Docker image and CI for getmail6

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,35 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/**'
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.11-slim
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install getmail6 and OAuth2 libraries
+RUN pip install --no-cache-dir getmail6 google-auth-oauthlib msal
+
+# Default locations (can be overridden by environment variables)
+ENV GETMAIL_CONFIG=/etc/getmail/getmailrc \
+    OAUTH2_CLIENT_ID="" \
+    OAUTH2_CLIENT_SECRET="" \
+    OAUTH2_REFRESH_TOKEN=""
+
+# Volumes for configuration and mail storage
+VOLUME ["/etc/getmail", "/mail"]
+
+WORKDIR /mail
+
+ENTRYPOINT ["getmail"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# getmail6 container
+
+This repository provides a minimal Docker image for [getmail6](https://github.com/getmail6/getmail6) so that emails from external providers can be aggregated and stored locally. The image is intended to be used in a Kubernetes environment managed by ArgoCD and the Stalwart mail server.
+
+## Features
+
+- Based on `python:3.11-slim` for a small footprint.
+- Installs `getmail6` and OAuth2 dependencies (`google-auth-oauthlib`, `msal`).
+- Designed for configuration via environment variables so secrets can be managed with Kubernetes ConfigMaps and Secrets.
+- GitHub Actions workflow builds and publishes the image to GitHub Container Registry.
+
+## Usage
+
+Mount your `getmailrc` configuration file and a directory to store retrieved mail:
+
+```bash
+docker run \
+  -v /path/to/getmailrc:/etc/getmail/getmailrc:ro \
+  -v /path/to/mail:/mail \
+  -e OAUTH2_CLIENT_ID=your-client-id \
+  -e OAUTH2_CLIENT_SECRET=your-client-secret \
+  -e OAUTH2_REFRESH_TOKEN=your-refresh-token \
+  ghcr.io/your-user/your-repo:latest
+```
+
+`getmail` will run with the provided configuration and store mail under `/mail`.
+
+## GitHub Actions
+
+The included workflow (`.github/workflows/docker-image.yml`) automatically builds the Docker image and pushes it to GitHub Container Registry when changes are pushed to the `main` branch.
+
+## Next Steps
+
+- Configure OAuth2 credentials for Gmail or Outlook and supply them via environment variables or Kubernetes secrets.
+- Set up scheduled execution (e.g., using CronJob in Kubernetes) to run `getmail` periodically.
+- Integrate the container with your Stalwart mail server for local delivery.


### PR DESCRIPTION
## Summary
- build a minimal docker image with getmail6 and OAuth2 libs
- add GitHub Actions workflow to push image to ghcr
- document usage and next steps in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6860ad0a58508333a32fec15814d0f5b